### PR TITLE
Use `std::cout` instead of `qInfo`

### DIFF
--- a/list-intersection/1-paul/main.cpp
+++ b/list-intersection/1-paul/main.cpp
@@ -1,5 +1,6 @@
-#include <QDebug>
+#include <iostream>
 #include <QFile>
+#include <QSet>
 
 int main(int, const char * [])
 {
@@ -10,12 +11,12 @@ int main(int, const char * [])
     QFile words2("words.2");
     words2.open(QFile::ReadOnly);
     auto list2 = words2.readAll().split('\n');
-    qSort(list2.begin(), list2.end());
+    std::sort(list2.begin(), list2.end());
 
     foreach (const QByteArray &word, list2)
     {
         if (list.contains(word)) {
-            qInfo().noquote() << word;
+            std::cout << word.toStdString() << '\n';
         }
     }
     return EXIT_SUCCESS;


### PR DESCRIPTION
`qInfo` is pretty handy, but does include a number of features we don't need, and `std::cout` is roughly twice as fast.

Also swapped `qSort` for `std::sort` as `qSort` is now obsoleted, with `std::sort` the recommended replacement - https://doc.qt.io/qt-5/qtalgorithms-obsolete.html#qSort

Switching to `std::sort` made no appreciable difference in performance on my machine.